### PR TITLE
Fix crash when an arrow is not in the inventory

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-##Advanced Combat
+## Advanced Combat
 
 This mod provides extremely powerful swords along with more flexible item enchanting. From advanced wooden swords to the incredible advanced nether star sword, this mod is sure to quench your thirst for power.
 This mod also includes enchantment upgrades, which allow you to pick and choose enchantments for your tools and armor without needing an enchantment table or enchanted books. Simply craft the item with the upgrade and its enchantment level will go up by one.

--- a/src/main/java/com/advancedcombat/items/ItemBowAdvanced.java
+++ b/src/main/java/com/advancedcombat/items/ItemBowAdvanced.java
@@ -60,7 +60,7 @@ public class ItemBowAdvanced extends ItemBow implements IItemAdvanced {
 				}
 			}
 
-			return null;
+			return ItemStack.EMPTY;
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes the crash when there is no inventory in the players inventory and they shot the advanced bow, I have my doubt this gets fixed so I made my own version to use until this gets fixed [My version](https://www.curseforge.com/minecraft/mc-mods/advanced-combat-oc-edition)

also fixed the syntax error in readme.md